### PR TITLE
Generate catalog in CI builds

### DIFF
--- a/.tekton/catalog-4-12-pull-request.yaml
+++ b/.tekton/catalog-4-12-pull-request.yaml
@@ -35,6 +35,8 @@ spec:
     - name: build-platforms
       value:
       - linux/x86_64
+    - name: ocp-version
+      value: "v4.12"
   pipelineRef:
     name: multi-platform-fbc-image-build
   taskRunTemplate: {}

--- a/.tekton/catalog-4-12-push.yaml
+++ b/.tekton/catalog-4-12-push.yaml
@@ -32,6 +32,8 @@ spec:
     - name: additional-tags
       value:
       - v4.12
+    - name: ocp-version
+      value: "v4.12"
   pipelineRef:
     name: multi-platform-fbc-image-build
   taskRunTemplate: {}

--- a/.tekton/catalog-4-13-pull-request.yaml
+++ b/.tekton/catalog-4-13-pull-request.yaml
@@ -35,6 +35,8 @@ spec:
     - name: build-platforms
       value:
       - linux/x86_64
+    - name: ocp-version
+      value: "v4.13"
   pipelineRef:
     name: multi-platform-fbc-image-build
   taskRunTemplate: {}

--- a/.tekton/catalog-4-13-push.yaml
+++ b/.tekton/catalog-4-13-push.yaml
@@ -32,6 +32,8 @@ spec:
     - name: additional-tags
       value:
       - v4.13
+    - name: ocp-version
+      value: "v4.13"
   pipelineRef:
     name: multi-platform-fbc-image-build
   taskRunTemplate: {}

--- a/.tekton/catalog-4-14-pull-request.yaml
+++ b/.tekton/catalog-4-14-pull-request.yaml
@@ -35,6 +35,8 @@ spec:
     - name: build-platforms
       value:
       - linux/x86_64
+    - name: ocp-version
+      value: "v4.14"
   pipelineRef:
     name: multi-platform-fbc-image-build
   taskRunTemplate: {}

--- a/.tekton/catalog-4-14-push.yaml
+++ b/.tekton/catalog-4-14-push.yaml
@@ -32,6 +32,8 @@ spec:
     - name: additional-tags
       value:
       - v4.14
+    - name: ocp-version
+      value: "v4.14"
   pipelineRef:
     name: multi-platform-fbc-image-build
   taskRunTemplate: {}

--- a/.tekton/catalog-4-15-pull-request.yaml
+++ b/.tekton/catalog-4-15-pull-request.yaml
@@ -32,6 +32,8 @@ spec:
       value: Dockerfile
     - name: path-context
       value: catalog/v4.15
+    - name: ocp-version
+      value: "v4.15"
     - name: build-platforms
       value:
       - linux/x86_64

--- a/.tekton/catalog-4-15-push.yaml
+++ b/.tekton/catalog-4-15-push.yaml
@@ -29,6 +29,8 @@ spec:
       value: Dockerfile
     - name: path-context
       value: catalog/v4.15
+    - name: ocp-version
+      value: "v4.15"
     - name: additional-tags
       value:
       - v4.15

--- a/.tekton/catalog-4-16-pull-request.yaml
+++ b/.tekton/catalog-4-16-pull-request.yaml
@@ -32,6 +32,8 @@ spec:
       value: Dockerfile
     - name: path-context
       value: catalog/v4.16
+    - name: ocp-version
+      value: "v4.16"
     - name: build-platforms
       value:
       - linux/x86_64

--- a/.tekton/catalog-4-16-push.yaml
+++ b/.tekton/catalog-4-16-push.yaml
@@ -29,6 +29,8 @@ spec:
       value: Dockerfile
     - name: path-context
       value: catalog/v4.16
+    - name: ocp-version
+      value: "v4.16"
     - name: additional-tags
       value:
       - v4.16

--- a/.tekton/catalog-4-17-pull-request.yaml
+++ b/.tekton/catalog-4-17-pull-request.yaml
@@ -32,6 +32,8 @@ spec:
       value: Dockerfile
     - name: path-context
       value: catalog/v4.17
+    - name: ocp-version
+      value: "v4.17"
     - name: build-platforms
       value:
       - linux/x86_64

--- a/.tekton/catalog-4-17-push.yaml
+++ b/.tekton/catalog-4-17-push.yaml
@@ -32,6 +32,8 @@ spec:
     - name: additional-tags
       value:
       - v4.17
+    - name: ocp-version
+      value: "v4.17"
   pipelineRef:
     name: multi-platform-fbc-image-build
   taskRunTemplate: {}

--- a/.tekton/catalog-4-18-pull-request.yaml
+++ b/.tekton/catalog-4-18-pull-request.yaml
@@ -32,6 +32,8 @@ spec:
       value: Dockerfile
     - name: path-context
       value: catalog/v4.18
+    - name: ocp-version
+      value: "v4.18"
     - name: build-platforms
       value:
       - linux/x86_64

--- a/.tekton/catalog-4-18-push.yaml
+++ b/.tekton/catalog-4-18-push.yaml
@@ -29,6 +29,8 @@ spec:
       value: Dockerfile
     - name: path-context
       value: catalog/v4.18
+    - name: ocp-version
+      value: "v4.18"
     - name: additional-tags
       value:
       - v4.18

--- a/.tekton/catalog-4-19-pull-request.yaml
+++ b/.tekton/catalog-4-19-pull-request.yaml
@@ -32,6 +32,8 @@ spec:
       value: Dockerfile
     - name: path-context
       value: catalog/v4.19
+    - name: ocp-version
+      value: "v4.19"
     - name: build-platforms
       value:
       - linux/x86_64

--- a/.tekton/catalog-4-19-push.yaml
+++ b/.tekton/catalog-4-19-push.yaml
@@ -29,6 +29,8 @@ spec:
       value: Dockerfile
     - name: path-context
       value: catalog/v4.19
+    - name: ocp-version
+      value: "v4.19"
     - name: additional-tags
       value:
       - v4.19

--- a/.tekton/multi-platform-fbc-image-build.yaml
+++ b/.tekton/multi-platform-fbc-image-build.yaml
@@ -152,18 +152,33 @@ spec:
     workspaces:
     - name: basic-auth
       workspace: git-auth
+  # Generate catalog
+  - name: generate-catalog
+    taskRef:
+      name: generate-catalog
+    runAfter:
+      - clone-repository
+    params:
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: ocp-version
+        value: $(params.ocp-version)
   - name: prefetch-dependencies
     params:
     - name: input
       value: $(params.prefetch-input)
     - name: SOURCE_ARTIFACT
-      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      value: $(tasks.generate-catalog.results.SOURCE_ARTIFACT)
     - name: ociStorage
       value: $(params.output-image).prefetch
     - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
     runAfter:
-    - clone-repository
+    - generate-catalog
     taskRef:
       params:
       - name: name
@@ -178,33 +193,6 @@ spec:
       workspace: git-auth
     - name: netrc
       workspace: netrc
-  - name: run-script
-    params:
-    - name: ociStorage
-      value: $(params.output-image).script
-    - name: ociArtifactExpiresAfter
-      value: $(params.image-expires-after)
-    - name: SCRIPT_RUNNER_IMAGE 
-      value: registry.redhat.io/ubi9/ubi:latest
-    - name: HERMETIC
-      value: "false"
-    - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-    - name: SCRIPT
-      value: |
-        yum install make -y
-        make catalog ocp=$(params.ocp-version)
-    runAfter:
-    - prefetch-dependencies
-    taskRef:
-      params:
-      - name: name
-        value: run-script-oci-ta
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:1dcc9805bdc20708f87126455c01e0c49be9d79f0c140220a71c85e49979b96d
-      - name: kind
-        value: task
-      resolver: bundles
   - matrix:
       params:
       - name: PLATFORM
@@ -232,16 +220,13 @@ spec:
     - name: BUILD_ARGS_FILE
       value: $(params.build-args-file)
     - name: SOURCE_ARTIFACT
-      value: $(tasks.run-script.results.SCRIPT_ARTIFACT)
-    - name: ADDITIONAL_BASE_IMAGES
-      value:
-        - $(tasks.run-script.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: IMAGE_APPEND_PLATFORM
       value: "true"
     runAfter:
-    - run-script
+    - prefetch-dependencies
     taskRef:
       params:
       - name: name

--- a/.tekton/multi-platform-fbc-image-build.yaml
+++ b/.tekton/multi-platform-fbc-image-build.yaml
@@ -223,7 +223,7 @@ spec:
     - name: input
       value: $(params.prefetch-input)
     - name: SOURCE_ARTIFACT
-      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      value: $(tasks.generate-catalog.results.SOURCE_ARTIFACT)
     - name: ociStorage
       value: $(params.output-image).prefetch
     - name: ociArtifactExpiresAfter
@@ -277,7 +277,7 @@ spec:
     - name: IMAGE_APPEND_PLATFORM
       value: "true"
     runAfter:
-    - clone-repository
+    - prefetch-dependencies
     taskRef:
       params:
       - name: name

--- a/.tekton/multi-platform-fbc-image-build.yaml
+++ b/.tekton/multi-platform-fbc-image-build.yaml
@@ -152,33 +152,18 @@ spec:
     workspaces:
     - name: basic-auth
       workspace: git-auth
-  # Generate catalog
-  - name: generate-catalog
-    taskRef:
-      name: generate-catalog
-    runAfter:
-      - clone-repository
-    params:
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-      - name: ociStorage
-        value: $(params.output-image).git
-      - name: ociArtifactExpiresAfter
-        value: $(params.image-expires-after)
-      - name: ocp-version
-        value: $(params.ocp-version)
   - name: prefetch-dependencies
     params:
     - name: input
       value: $(params.prefetch-input)
     - name: SOURCE_ARTIFACT
-      value: $(tasks.generate-catalog.results.SOURCE_ARTIFACT)
+      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage
       value: $(params.output-image).prefetch
     - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
     runAfter:
-    - generate-catalog
+    - clone-repository
     taskRef:
       params:
       - name: name
@@ -193,6 +178,33 @@ spec:
       workspace: git-auth
     - name: netrc
       workspace: netrc
+  - name: run-script
+    params:
+    - name: ociStorage
+      value: $(params.output-image).script
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    - name: SCRIPT_RUNNER_IMAGE 
+      value: registry.redhat.io/ubi9/ubi:latest
+    - name: HERMETIC
+      value: "false"
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: SCRIPT
+      value: |
+        yum install make -y
+        make catalog ocp=$(params.ocp-version)
+    runAfter:
+    - prefetch-dependencies
+    taskRef:
+      params:
+      - name: name
+        value: run-script-oci-ta
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta:0.1@sha256:1dcc9805bdc20708f87126455c01e0c49be9d79f0c140220a71c85e49979b96d
+      - name: kind
+        value: task
+      resolver: bundles
   - matrix:
       params:
       - name: PLATFORM
@@ -220,13 +232,16 @@ spec:
     - name: BUILD_ARGS_FILE
       value: $(params.build-args-file)
     - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      value: $(tasks.run-script.results.SCRIPT_ARTIFACT)
+    - name: ADDITIONAL_BASE_IMAGES
+      value:
+        - $(tasks.run-script.results.SCRIPT_RUNNER_IMAGE_REFERENCE)
     - name: CACHI2_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: IMAGE_APPEND_PLATFORM
       value: "true"
     runAfter:
-    - prefetch-dependencies
+    - run-script
     taskRef:
       params:
       - name: name

--- a/.tekton/multi-platform-fbc-image-build.yaml
+++ b/.tekton/multi-platform-fbc-image-build.yaml
@@ -168,6 +168,11 @@ spec:
         - description: The Trusted Artifact URI pointing to the artifact with the application source code.
           name: SOURCE_ARTIFACT
           type: string
+      results:
+        - name: SOURCE_ARTIFACT
+          description: The Trusted Artifact URI pointing to the artifact with
+            the application source code.
+          type: string
       stepTemplate:
         volumeMounts:
           - mountPath: /var/workdir

--- a/.tekton/multi-platform-fbc-image-build.yaml
+++ b/.tekton/multi-platform-fbc-image-build.yaml
@@ -157,6 +157,10 @@ spec:
     params:
       - name: SOURCE_ARTIFACT
         value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).git
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
     runAfter:
       - clone-repository
     taskSpec:
@@ -179,6 +183,29 @@ spec:
           image: registry.access.redhat.com/ubi8/ubi:latest
           workingDir: /var/workdir/source
           script: yum install make -y && make catalog ocp=$(params.ocp-version)
+        - name: create-trusted-artifact
+          image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:4689f88dd253bd1feebf57f1a76a5a751880f739000719cd662bbdc76990a7fd
+          args:
+            - create
+            - --store
+            - $(params.ociStorage)
+            - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+            - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+              name: trusted-ca
+              readOnly: true
+              subPath: ca-bundle.crt
+          env:
+            - name: IMAGE_EXPIRES_AFTER
+              value: $(params.ociArtifactExpiresAfter)
+          computeResources:
+            limits:
+              memory: 3Gi
+            requests:
+              cpu: "1"
+              memory: 3Gi
       volumes:
         # Volume to store a copy of the source code accessible only to this Task.
         - name: workdir

--- a/.tekton/multi-platform-fbc-image-build.yaml
+++ b/.tekton/multi-platform-fbc-image-build.yaml
@@ -88,6 +88,10 @@ spec:
     description: Additional tags to apply to the image in the registry. Set this only for push events, setting it for PR events will break the bundle update script.
     type: array
     default: []
+  - name: ocp-version
+    description: OpenShift version to use for the FBC build. Prefix with "v" (e.g., "v4.12").
+    type: string
+    default: ""
   results:
   - description: ""
     name: IMAGE_URL
@@ -149,9 +153,8 @@ spec:
     - name: basic-auth
       workspace: git-auth
   # Generate catalog
-  - name: test-generation
+  - name: generate-catalog
     params:
-      # New parameter to use the Trusted Artifact from the git-clone Task.
       - name: SOURCE_ARTIFACT
         value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     runAfter:
@@ -166,7 +169,7 @@ spec:
           - mountPath: /var/workdir
             name: workdir
       steps:
-        # New step to fetch the Trusted Artifact and make it available to the next steps.
+        # Step to fetch the Trusted Artifact and make it available to the next steps.
         - name: use-trusted-artifact
           image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
           args:
@@ -175,9 +178,9 @@ spec:
         - name: catalog-build
           image: registry.access.redhat.com/ubi8/ubi:latest
           workingDir: /var/workdir/source
-          script: pwd && ls -lh
+          script: yum install make && make catalog ocp=$(params.ocp-version)
       volumes:
-        # New volume to store a copy of the source code accessible only to this Task.
+        # Volume to store a copy of the source code accessible only to this Task.
         - name: workdir
           emptyDir: {}
   # task end
@@ -192,7 +195,7 @@ spec:
     - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
     runAfter:
-    - clone-repository
+    - generate-catalog
     taskRef:
       params:
       - name: name

--- a/.tekton/multi-platform-fbc-image-build.yaml
+++ b/.tekton/multi-platform-fbc-image-build.yaml
@@ -148,6 +148,39 @@ spec:
     workspaces:
     - name: basic-auth
       workspace: git-auth
+  # Generate catalog
+  - name: test-generation
+    params:
+      # New parameter to use the Trusted Artifact from the git-clone Task.
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+    runAfter:
+      - clone-repository
+    taskSpec:
+      params:
+        - description: The Trusted Artifact URI pointing to the artifact with the application source code.
+          name: SOURCE_ARTIFACT
+          type: string
+      stepTemplate:
+        volumeMounts:
+          - mountPath: /var/workdir
+            name: workdir
+      steps:
+        # New step to fetch the Trusted Artifact and make it available to the next steps.
+        - name: use-trusted-artifact
+          image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+          args:
+            - use
+            - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - name: catalog-build
+          image: registry.access.redhat.com/ubi8/ubi:latest
+          workingDir: /var/workdir/source
+          script: pwd && ls -lh
+      volumes:
+        # New volume to store a copy of the source code accessible only to this Task.
+        - name: workdir
+          emptyDir: {}
+  # task end
   - name: prefetch-dependencies
     params:
     - name: input

--- a/.tekton/multi-platform-fbc-image-build.yaml
+++ b/.tekton/multi-platform-fbc-image-build.yaml
@@ -178,7 +178,7 @@ spec:
         - name: catalog-build
           image: registry.access.redhat.com/ubi8/ubi:latest
           workingDir: /var/workdir/source
-          script: yum install make && make catalog ocp=$(params.ocp-version)
+          script: yum install make -y && make catalog ocp=$(params.ocp-version)
       volumes:
         # Volume to store a copy of the source code accessible only to this Task.
         - name: workdir

--- a/.tekton/multi-platform-fbc-image-build.yaml
+++ b/.tekton/multi-platform-fbc-image-build.yaml
@@ -154,6 +154,10 @@ spec:
       workspace: git-auth
   # Generate catalog
   - name: generate-catalog
+    taskRef:
+      name: generate-catalog
+    runAfter:
+      - clone-repository
     params:
       - name: SOURCE_ARTIFACT
         value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
@@ -161,68 +165,8 @@ spec:
         value: $(params.output-image).git
       - name: ociArtifactExpiresAfter
         value: $(params.image-expires-after)
-    runAfter:
-      - clone-repository
-    taskSpec:
-      params:
-        - description: The Trusted Artifact URI pointing to the artifact with the application source code.
-          name: SOURCE_ARTIFACT
-          type: string
-      results:
-        - name: SOURCE_ARTIFACT
-          description: The Trusted Artifact URI pointing to the artifact with
-            the application source code.
-          type: string
-      stepTemplate:
-        volumeMounts:
-          - mountPath: /var/workdir
-            name: workdir
-      steps:
-        # Step to fetch the Trusted Artifact and make it available to the next steps.
-        - name: use-trusted-artifact
-          image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
-          args:
-            - use
-            - $(params.SOURCE_ARTIFACT)=/var/workdir/source
-        - name: catalog-build
-          image: registry.access.redhat.com/ubi8/ubi:latest
-          workingDir: /var/workdir/source
-          script: yum install make -y && make catalog ocp=$(params.ocp-version)
-        - name: create-trusted-artifact
-          image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:4689f88dd253bd1feebf57f1a76a5a751880f739000719cd662bbdc76990a7fd
-          args:
-            - create
-            - --store
-            - $(params.ociStorage)
-            - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source
-          volumeMounts:
-            - mountPath: /var/workdir
-              name: workdir
-            - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
-              name: trusted-ca
-              readOnly: true
-              subPath: ca-bundle.crt
-          env:
-            - name: IMAGE_EXPIRES_AFTER
-              value: $(params.ociArtifactExpiresAfter)
-          computeResources:
-            limits:
-              memory: 3Gi
-            requests:
-              cpu: "1"
-              memory: 3Gi
-      volumes:
-        # Volume to store a copy of the source code accessible only to this Task.
-        - name: workdir
-          emptyDir: {}
-        - name: trusted-ca
-          configMap:
-            items:
-              - key: $(params.caTrustConfigMapKey)
-                path: ca-bundle.crt
-            name: $(params.caTrustConfigMapName)
-            optional: true
-  # task end
+      - name: ocp-version
+        value: $(params.ocp-version)
   - name: prefetch-dependencies
     params:
     - name: input

--- a/.tekton/multi-platform-fbc-image-build.yaml
+++ b/.tekton/multi-platform-fbc-image-build.yaml
@@ -210,6 +210,13 @@ spec:
         # Volume to store a copy of the source code accessible only to this Task.
         - name: workdir
           emptyDir: {}
+        - name: trusted-ca
+          configMap:
+            items:
+              - key: $(params.caTrustConfigMapKey)
+                path: ca-bundle.crt
+            name: $(params.caTrustConfigMapName)
+            optional: true
   # task end
   - name: prefetch-dependencies
     params:

--- a/.tekton/tasks/generate-catalog.yaml
+++ b/.tekton/tasks/generate-catalog.yaml
@@ -1,0 +1,76 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: generate-catalog
+spec:
+  params:
+    - name: SOURCE_ARTIFACT
+      type: string
+      description: The Trusted Artifact URI pointing to the artifact with the application source code.
+    - name: ociStorage
+      type: string
+      description: OCI storage location to push the Trusted Artifact.
+    - name: ociArtifactExpiresAfter
+      type: string
+      description: Expiry metadata for the artifact in OCI.
+    - name: ocp-version
+      type: string
+      description: OpenShift version used to generate catalog.
+    - name: caTrustConfigMapName
+      type: string
+      default: ""
+    - name: caTrustConfigMapKey
+      type: string
+      default: ""
+  results:
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI of the generated catalog.
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+
+    - name: catalog-build
+      image: registry.access.redhat.com/ubi8/ubi:latest
+      workingDir: /var/workdir/source
+      script: |
+        yum install make -y
+        make catalog ocp=$(params.ocp-version)
+
+    - name: create-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:4689f88dd253bd1feebf57f1a76a5a751880f739000719cd662bbdc76990a7fd
+      args:
+        - create
+        - --store
+        - $(params.ociStorage)
+        - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+      env:
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.ociArtifactExpiresAfter)
+      computeResources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi
+  volumes:
+    - name: workdir
+      emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        optional: true
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt

--- a/.tekton/tasks/generate-catalog.yaml
+++ b/.tekton/tasks/generate-catalog.yaml
@@ -17,11 +17,13 @@ spec:
       type: string
       description: OpenShift version used to generate catalog.
     - name: caTrustConfigMapName
+      description: The name of the ConfigMap to read CA bundle data from.
       type: string
-      default: ""
+      default: trusted-ca
     - name: caTrustConfigMapKey
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
       type: string
-      default: ""
+      default: ca-bundle.crt
   results:
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI of the generated catalog.

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,12 @@ catalog-template:
 	python3 generate-catalog-template.py
 
 .PHONY: catalog
+# Detect platform and set SED_INPLACE accordingly
+ifeq ($(shell uname), Darwin)
+  SED_INPLACE = sed -i ''
+else
+  SED_INPLACE = sed -i
+endif
 catalog: deps
 	@if [ -z "$(ocp)" ]; then \
 		echo "Error: 'ocp' parameter is required. Usage: make catalog ocp=v4.14"; \
@@ -65,4 +71,4 @@ catalog: deps
 	$(OPM) alpha render-template basic catalog/$$version/template.yaml $$MIGRATE -o yaml > catalog/$$version/openshift-gitops-operator/catalog.yaml; \
 	ls -lh catalog/$$version/openshift-gitops-operator/catalog.yaml; \
 	echo "Replacing quay.io with registry.redhat.io in $$version catalog..."; \
-	sed -i '' 's~quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle~registry.redhat.io/openshift-gitops-1/gitops-operator-bundle~g' catalog/$$version/openshift-gitops-operator/catalog.yaml
+	$(SED_INPLACE) 's~quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle~registry.redhat.io/openshift-gitops-1/gitops-operator-bundle~g' catalog/$$version/openshift-gitops-operator/catalog.yaml

--- a/Makefile
+++ b/Makefile
@@ -63,5 +63,6 @@ catalog: deps
 		MIGRATE=""; \
 	fi; \
 	$(OPM) alpha render-template basic catalog/$$version/template.yaml $$MIGRATE -o yaml > catalog/$$version/openshift-gitops-operator/catalog.yaml; \
+	ls -lh catalog/$$version/openshift-gitops-operator/catalog.yaml; \
 	echo "Replacing quay.io with registry.redhat.io in $$version catalog..."; \
 	sed -i '' 's~quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle~registry.redhat.io/openshift-gitops-1/gitops-operator-bundle~g' catalog/$$version/openshift-gitops-operator/catalog.yaml

--- a/Makefile
+++ b/Makefile
@@ -47,18 +47,21 @@ catalog-template:
 	python3 generate-catalog-template.py
 
 .PHONY: catalog
-catalog:
-	@for version in $(OCP_VERSIONS); do \
-		echo "Rendering catalog for v$$version..."; \
-		mkdir -p catalog/v$$version/openshift-gitops-operator; \
-		MAJOR=$$(echo $$version | cut -d. -f1); \
-		MINOR=$$(echo $$version | cut -d. -f2); \
-		if [ "$$MAJOR" -eq 4 ] && [ "$$MINOR" -ge 17 ]; then \
-			MIGRATE="--migrate-level=bundle-object-to-csv-metadata"; \
-		else \
-			MIGRATE=""; \
-		fi; \
-		$(OPM) alpha render-template basic catalog/v$$version/template.yaml $$MIGRATE -o yaml > catalog/v$$version/openshift-gitops-operator/catalog.yaml; \
-		echo "Replacing quay.io with registry.redhat.io in v$$version catalog..."; \
-		sed -i '' 's~quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle~registry.redhat.io/openshift-gitops-1/gitops-operator-bundle~g' catalog/v$$version/openshift-gitops-operator/catalog.yaml; \
-	done
+catalog: deps
+	@if [ -z "$(ocp)" ]; then \
+		echo "Error: 'ocp' parameter is required. Usage: make catalog ocp=v4.14"; \
+		exit 1; \
+	fi; \
+	version="$${ocp}"; \
+	echo "Rendering catalog for $$version..."; \
+	mkdir -p catalog/$$version/openshift-gitops-operator; \
+	MAJOR=$$(echo $$version | cut -d. -f1 | sed 's/v//'); \
+	MINOR=$$(echo $$version | cut -d. -f2); \
+	if [ "$$MAJOR" -eq 4 ] && [ "$$MINOR" -ge 17 ]; then \
+		MIGRATE="--migrate-level=bundle-object-to-csv-metadata"; \
+	else \
+		MIGRATE=""; \
+	fi; \
+	$(OPM) alpha render-template basic catalog/$$version/template.yaml $$MIGRATE -o yaml > catalog/$$version/openshift-gitops-operator/catalog.yaml; \
+	echo "Replacing quay.io with registry.redhat.io in $$version catalog..."; \
+	sed -i '' 's~quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle~registry.redhat.io/openshift-gitops-1/gitops-operator-bundle~g' catalog/$$version/openshift-gitops-operator/catalog.yaml

--- a/catalog/v4.12/README.md
+++ b/catalog/v4.12/README.md
@@ -1,0 +1,3 @@
+# OpenShift GitOps Catalog
+
+The `./openshift-gitops-operator/catalog.yaml` file is automatically generated during the CI build process using the `make catalog` target.

--- a/catalog/v4.13/README.md
+++ b/catalog/v4.13/README.md
@@ -1,0 +1,3 @@
+# OpenShift GitOps Catalog
+
+The `./openshift-gitops-operator/catalog.yaml` file is automatically generated during the CI build process using the `make catalog` target.

--- a/catalog/v4.14/README.md
+++ b/catalog/v4.14/README.md
@@ -1,0 +1,3 @@
+# OpenShift GitOps Catalog
+
+The `./openshift-gitops-operator/catalog.yaml` file is automatically generated during the CI build process using the `make catalog` target.

--- a/catalog/v4.15/README.md
+++ b/catalog/v4.15/README.md
@@ -1,0 +1,3 @@
+# OpenShift GitOps Catalog
+
+The `./openshift-gitops-operator/catalog.yaml` file is automatically generated during the CI build process using the `make catalog` target.

--- a/catalog/v4.16/README.md
+++ b/catalog/v4.16/README.md
@@ -1,0 +1,3 @@
+# OpenShift GitOps Catalog
+
+The `./openshift-gitops-operator/catalog.yaml` file is automatically generated during the CI build process using the `make catalog` target.

--- a/catalog/v4.17/README.md
+++ b/catalog/v4.17/README.md
@@ -1,0 +1,3 @@
+# OpenShift GitOps Catalog
+
+The `./openshift-gitops-operator/catalog.yaml` file is automatically generated during the CI build process using the `make catalog` target.

--- a/catalog/v4.18/README.md
+++ b/catalog/v4.18/README.md
@@ -1,0 +1,3 @@
+# OpenShift GitOps Catalog
+
+The `./openshift-gitops-operator/catalog.yaml` file is automatically generated during the CI build process using the `make catalog` target.

--- a/catalog/v4.19/README.md
+++ b/catalog/v4.19/README.md
@@ -1,0 +1,3 @@
+# OpenShift GitOps Catalog
+
+The `./openshift-gitops-operator/catalog.yaml` file is automatically generated during the CI build process using the `make catalog` target.


### PR DESCRIPTION
This PR adds a task to generate the catalog during CI builds.

Previously, we generated the catalog locally using `opm alpha render-template basic...`. However, the resulting catalog.yaml is large (>100 MB) and had to be tracked via Git LFS. This worked fine until recently, when we started hitting GitHub's LFS bandwidth limits.

```
INFO: Using mounted CA bundle: /mnt/trusted-ca/ca-bundle.crt
{"level":"error","ts":1752816875.5128977,"caller":"git/git.go:53","msg":"Error running git [checkout -f FETCH_HEAD]: exit status 128\nDownloading catalog/v4.12/openshift-gitops-operator/catalog.yaml (116 MB)\nError downloading object: catalog/v4.12/openshift-gitops-operator/catalog.yaml (c14222d): Smudge error: Error downloading catalog/v4.12/openshift-gitops-operator/catalog.yaml (c14222d4abd40d774c840cbb09b83cca1e72bf40a3e8918df2c11ff15e04076c): batch response: This repository exceeded its LFS budget. The account responsible for the budget should increase it to restore access.\n\nErrors logged to '/var/workdir/source/.git/lfs/logs/20250718T053435.510273814.log'.\nUse `git lfs logs last` to view the log.\nerror: external filter 'git-lfs filter-process' failed\nfatal: catalog/v4.12/openshift-gitops-operator/catalog.yaml: smudge filter lfs failed\n","stacktrace":"github.com/tektoncd-catalog/git-clone/git-init/git.run\n\t/opt/app-root/src/git-init/git/git.go:53\ngithub.com/tektoncd-catalog/git-clone/git-init/git.Fetch\n\t/opt/app-root/src/git-init/git/git.go:164\nmain.main\n\t/opt/app-root/src/git-init/main.go:52\nruntime.main\n\t/usr/lib/golang/src/runtime/proc.go:267"}
{"level":"fatal","ts":1752816875.5129938,"caller":"git-init/main.go:53","msg":"Error fetching git repository: exit status 128","stacktrace":"main.main\n\t/opt/app-root/src/git-init/main.go:53\nruntime.main\n\t/usr/lib/golang/src/runtime/proc.go:267"}
```

By generating the catalog dynamically in CI, we can avoid storing large artifacts in Git LFS and prevent such issues in the future.

