### PR TITLE
Build single arch fbc images for 4.12 & 4.13

### DIFF
--- a/.tekton/catalog-4-12-push.yaml
+++ b/.tekton/catalog-4-12-push.yaml
@@ -34,6 +34,9 @@ spec:
       - v4.12
     - name: ocp-version
       value: "v4.12"
+    - name: build-platforms
+      value:
+      - linux/x86_64
   pipelineRef:
     name: multi-platform-fbc-image-build
   taskRunTemplate: {}

--- a/.tekton/catalog-4-13-push.yaml
+++ b/.tekton/catalog-4-13-push.yaml
@@ -34,6 +34,9 @@ spec:
       - v4.13
     - name: ocp-version
       value: "v4.13"
+    - name: build-platforms
+      value:
+      - linux/x86_64
   pipelineRef:
     name: multi-platform-fbc-image-build
   taskRunTemplate: {}


### PR DESCRIPTION
OCP team dropped multi arch support for operator-registry images. Hence building multi-arch catalog image is not possible. However, the final release artifact will still be multiarch. Konflux FBC release pipeline will handle multi-arch image creation during release.

https://issues.redhat.com/browse/CLOUDDST-28358