### PR TITLE
chore(release-candidate): update catalog for build v1.20.2-1

### DIFF
--- a/catalog/v4.12/template.yaml
+++ b/catalog/v4.12/template.yaml
@@ -955,6 +955,8 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1281,9 +1283,13 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2a592c2905c9b77ee0606abf58b4ac4f968e2363daa72d3829229b7c2e20b58f
 schema: olm.template.basic
 

--- a/catalog/v4.13/template.yaml
+++ b/catalog/v4.13/template.yaml
@@ -886,6 +886,8 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1133,9 +1135,13 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2a592c2905c9b77ee0606abf58b4ac4f968e2363daa72d3829229b7c2e20b58f
 schema: olm.template.basic
 

--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -886,6 +886,8 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1133,9 +1135,13 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2a592c2905c9b77ee0606abf58b4ac4f968e2363daa72d3829229b7c2e20b58f
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -886,6 +886,8 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1133,9 +1135,13 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2a592c2905c9b77ee0606abf58b4ac4f968e2363daa72d3829229b7c2e20b58f
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -886,6 +886,8 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1133,9 +1135,13 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2a592c2905c9b77ee0606abf58b4ac4f968e2363daa72d3829229b7c2e20b58f
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -886,6 +886,8 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1133,9 +1135,13 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2a592c2905c9b77ee0606abf58b4ac4f968e2363daa72d3829229b7c2e20b58f
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -886,6 +886,8 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1133,9 +1135,13 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2a592c2905c9b77ee0606abf58b4ac4f968e2363daa72d3829229b7c2e20b58f
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -886,6 +886,8 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1133,9 +1135,13 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2a592c2905c9b77ee0606abf58b4ac4f968e2363daa72d3829229b7c2e20b58f
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -886,6 +886,8 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1133,9 +1135,13 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2a592c2905c9b77ee0606abf58b4ac4f968e2363daa72d3829229b7c2e20b58f
 schema: olm.template.basic
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -886,6 +886,8 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1133,9 +1135,13 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2a592c2905c9b77ee0606abf58b4ac4f968e2363daa72d3829229b7c2e20b58f
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -886,6 +886,8 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1133,9 +1135,13 @@ entries:
     skipRange: '>=1.0.0 <1.20.0'
   - name: openshift-gitops-operator.v1.20.1
     replaces: openshift-gitops-operator.v1.20.0
+  - name: openshift-gitops-operator.v1.20.2
+    replaces: openshift-gitops-operator.v1.20.1
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2a592c2905c9b77ee0606abf58b4ac4f968e2363daa72d3829229b7c2e20b58f
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -73,3 +73,7 @@ channels:
         replaces: openshift-gitops-operator.v1.20.0
         skipRange: ''
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
+      - name: openshift-gitops-operator.v1.20.2
+        replaces: openshift-gitops-operator.v1.20.1
+        skipRange: ''
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2a592c2905c9b77ee0606abf58b4ac4f968e2363daa72d3829229b7c2e20b58f


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.20.2-1 <br>**Timestamp:** 20260407-102628 <br><br>Automatically generated by GitHub Actions.