### PR TITLE
chore(release-candidate): update catalog for build v1.18.5-2

### DIFF
--- a/catalog/v4.12/template.yaml
+++ b/catalog/v4.12/template.yaml
@@ -1233,6 +1233,8 @@ entries:
     replaces: openshift-gitops-operator.v1.18.2
   - name: openshift-gitops-operator.v1.18.4
     replaces: openshift-gitops-operator.v1.18.3
+  - name: openshift-gitops-operator.v1.18.5
+    replaces: openshift-gitops-operator.v1.18.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:8546401f9a96b0c397da8ab26306cca412e6fa6d11471c739177a5f533ba6f11
 - schema: olm.bundle
@@ -1291,5 +1293,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
 schema: olm.template.basic
 

--- a/catalog/v4.13/template.yaml
+++ b/catalog/v4.13/template.yaml
@@ -1085,6 +1085,8 @@ entries:
     replaces: openshift-gitops-operator.v1.18.2
   - name: openshift-gitops-operator.v1.18.4
     replaces: openshift-gitops-operator.v1.18.3
+  - name: openshift-gitops-operator.v1.18.5
+    replaces: openshift-gitops-operator.v1.18.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:8546401f9a96b0c397da8ab26306cca412e6fa6d11471c739177a5f533ba6f11
 - schema: olm.bundle
@@ -1143,5 +1145,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
 schema: olm.template.basic
 

--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -1085,6 +1085,8 @@ entries:
     replaces: openshift-gitops-operator.v1.18.2
   - name: openshift-gitops-operator.v1.18.4
     replaces: openshift-gitops-operator.v1.18.3
+  - name: openshift-gitops-operator.v1.18.5
+    replaces: openshift-gitops-operator.v1.18.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:8546401f9a96b0c397da8ab26306cca412e6fa6d11471c739177a5f533ba6f11
 - schema: olm.bundle
@@ -1143,5 +1145,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -1085,6 +1085,8 @@ entries:
     replaces: openshift-gitops-operator.v1.18.2
   - name: openshift-gitops-operator.v1.18.4
     replaces: openshift-gitops-operator.v1.18.3
+  - name: openshift-gitops-operator.v1.18.5
+    replaces: openshift-gitops-operator.v1.18.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:8546401f9a96b0c397da8ab26306cca412e6fa6d11471c739177a5f533ba6f11
 - schema: olm.bundle
@@ -1143,5 +1145,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -1085,6 +1085,8 @@ entries:
     replaces: openshift-gitops-operator.v1.18.2
   - name: openshift-gitops-operator.v1.18.4
     replaces: openshift-gitops-operator.v1.18.3
+  - name: openshift-gitops-operator.v1.18.5
+    replaces: openshift-gitops-operator.v1.18.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:8546401f9a96b0c397da8ab26306cca412e6fa6d11471c739177a5f533ba6f11
 - schema: olm.bundle
@@ -1143,5 +1145,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -1085,6 +1085,8 @@ entries:
     replaces: openshift-gitops-operator.v1.18.2
   - name: openshift-gitops-operator.v1.18.4
     replaces: openshift-gitops-operator.v1.18.3
+  - name: openshift-gitops-operator.v1.18.5
+    replaces: openshift-gitops-operator.v1.18.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:8546401f9a96b0c397da8ab26306cca412e6fa6d11471c739177a5f533ba6f11
 - schema: olm.bundle
@@ -1143,5 +1145,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -1085,6 +1085,8 @@ entries:
     replaces: openshift-gitops-operator.v1.18.2
   - name: openshift-gitops-operator.v1.18.4
     replaces: openshift-gitops-operator.v1.18.3
+  - name: openshift-gitops-operator.v1.18.5
+    replaces: openshift-gitops-operator.v1.18.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:8546401f9a96b0c397da8ab26306cca412e6fa6d11471c739177a5f533ba6f11
 - schema: olm.bundle
@@ -1143,5 +1145,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -1085,6 +1085,8 @@ entries:
     replaces: openshift-gitops-operator.v1.18.2
   - name: openshift-gitops-operator.v1.18.4
     replaces: openshift-gitops-operator.v1.18.3
+  - name: openshift-gitops-operator.v1.18.5
+    replaces: openshift-gitops-operator.v1.18.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:8546401f9a96b0c397da8ab26306cca412e6fa6d11471c739177a5f533ba6f11
 - schema: olm.bundle
@@ -1143,5 +1145,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -1085,6 +1085,8 @@ entries:
     replaces: openshift-gitops-operator.v1.18.2
   - name: openshift-gitops-operator.v1.18.4
     replaces: openshift-gitops-operator.v1.18.3
+  - name: openshift-gitops-operator.v1.18.5
+    replaces: openshift-gitops-operator.v1.18.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:8546401f9a96b0c397da8ab26306cca412e6fa6d11471c739177a5f533ba6f11
 - schema: olm.bundle
@@ -1143,5 +1145,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
 schema: olm.template.basic
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -1085,6 +1085,8 @@ entries:
     replaces: openshift-gitops-operator.v1.18.2
   - name: openshift-gitops-operator.v1.18.4
     replaces: openshift-gitops-operator.v1.18.3
+  - name: openshift-gitops-operator.v1.18.5
+    replaces: openshift-gitops-operator.v1.18.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:8546401f9a96b0c397da8ab26306cca412e6fa6d11471c739177a5f533ba6f11
 - schema: olm.bundle
@@ -1143,5 +1145,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -1085,6 +1085,8 @@ entries:
     replaces: openshift-gitops-operator.v1.18.2
   - name: openshift-gitops-operator.v1.18.4
     replaces: openshift-gitops-operator.v1.18.3
+  - name: openshift-gitops-operator.v1.18.5
+    replaces: openshift-gitops-operator.v1.18.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:8546401f9a96b0c397da8ab26306cca412e6fa6d11471c739177a5f533ba6f11
 - schema: olm.bundle
@@ -1143,5 +1145,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:f8301c386f55405c5933470d4034332b44559e59d4d99c2d70db0133551f9b73
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -49,6 +49,10 @@ channels:
         replaces: openshift-gitops-operator.v1.18.3
         skipRange: ''
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:6fc4720fce99dc2d20d5d30e153c01754937dd7aca0a6697e0ecb16c16cab2ac
+      - name: openshift-gitops-operator.v1.18.5
+        replaces: openshift-gitops-operator.v1.18.4
+        skipRange: ''
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
   - name: gitops-1.19
     versions:
       - name: openshift-gitops-operator.v1.19.0


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.18.5-2 <br>**Timestamp:** 20260413-024102 <br><br>Automatically generated by GitHub Actions.