### PR TITLE
chore(release-candidate): update catalog for build v1.19.3-1

### DIFF
--- a/catalog/v4.12/template.yaml
+++ b/catalog/v4.12/template.yaml
@@ -1262,6 +1262,8 @@ entries:
   - name: openshift-gitops-operator.v1.19.2
     replaces: openshift-gitops-operator.v1.19.1
     skipRange: '>=1.0.0 <1.19.0'
+  - name: openshift-gitops-operator.v1.19.3
+    replaces: openshift-gitops-operator.v1.19.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1295,5 +1297,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2bc42a4808fc4a7cdcae41851a92608357edeab3e60c70c47b0bf2b97eeae162
 schema: olm.template.basic
 

--- a/catalog/v4.13/template.yaml
+++ b/catalog/v4.13/template.yaml
@@ -1114,6 +1114,8 @@ entries:
   - name: openshift-gitops-operator.v1.19.2
     replaces: openshift-gitops-operator.v1.19.1
     skipRange: '>=1.0.0 <1.19.0'
+  - name: openshift-gitops-operator.v1.19.3
+    replaces: openshift-gitops-operator.v1.19.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1147,5 +1149,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2bc42a4808fc4a7cdcae41851a92608357edeab3e60c70c47b0bf2b97eeae162
 schema: olm.template.basic
 

--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -1114,6 +1114,8 @@ entries:
   - name: openshift-gitops-operator.v1.19.2
     replaces: openshift-gitops-operator.v1.19.1
     skipRange: '>=1.0.0 <1.19.0'
+  - name: openshift-gitops-operator.v1.19.3
+    replaces: openshift-gitops-operator.v1.19.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1147,5 +1149,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2bc42a4808fc4a7cdcae41851a92608357edeab3e60c70c47b0bf2b97eeae162
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -1114,6 +1114,8 @@ entries:
   - name: openshift-gitops-operator.v1.19.2
     replaces: openshift-gitops-operator.v1.19.1
     skipRange: '>=1.0.0 <1.19.0'
+  - name: openshift-gitops-operator.v1.19.3
+    replaces: openshift-gitops-operator.v1.19.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1147,5 +1149,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2bc42a4808fc4a7cdcae41851a92608357edeab3e60c70c47b0bf2b97eeae162
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -1114,6 +1114,8 @@ entries:
   - name: openshift-gitops-operator.v1.19.2
     replaces: openshift-gitops-operator.v1.19.1
     skipRange: '>=1.0.0 <1.19.0'
+  - name: openshift-gitops-operator.v1.19.3
+    replaces: openshift-gitops-operator.v1.19.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1147,5 +1149,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2bc42a4808fc4a7cdcae41851a92608357edeab3e60c70c47b0bf2b97eeae162
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -1114,6 +1114,8 @@ entries:
   - name: openshift-gitops-operator.v1.19.2
     replaces: openshift-gitops-operator.v1.19.1
     skipRange: '>=1.0.0 <1.19.0'
+  - name: openshift-gitops-operator.v1.19.3
+    replaces: openshift-gitops-operator.v1.19.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1147,5 +1149,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2bc42a4808fc4a7cdcae41851a92608357edeab3e60c70c47b0bf2b97eeae162
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -1114,6 +1114,8 @@ entries:
   - name: openshift-gitops-operator.v1.19.2
     replaces: openshift-gitops-operator.v1.19.1
     skipRange: '>=1.0.0 <1.19.0'
+  - name: openshift-gitops-operator.v1.19.3
+    replaces: openshift-gitops-operator.v1.19.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1147,5 +1149,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2bc42a4808fc4a7cdcae41851a92608357edeab3e60c70c47b0bf2b97eeae162
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -1114,6 +1114,8 @@ entries:
   - name: openshift-gitops-operator.v1.19.2
     replaces: openshift-gitops-operator.v1.19.1
     skipRange: '>=1.0.0 <1.19.0'
+  - name: openshift-gitops-operator.v1.19.3
+    replaces: openshift-gitops-operator.v1.19.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1147,5 +1149,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2bc42a4808fc4a7cdcae41851a92608357edeab3e60c70c47b0bf2b97eeae162
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -1114,6 +1114,8 @@ entries:
   - name: openshift-gitops-operator.v1.19.2
     replaces: openshift-gitops-operator.v1.19.1
     skipRange: '>=1.0.0 <1.19.0'
+  - name: openshift-gitops-operator.v1.19.3
+    replaces: openshift-gitops-operator.v1.19.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1147,5 +1149,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2bc42a4808fc4a7cdcae41851a92608357edeab3e60c70c47b0bf2b97eeae162
 schema: olm.template.basic
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -1114,6 +1114,8 @@ entries:
   - name: openshift-gitops-operator.v1.19.2
     replaces: openshift-gitops-operator.v1.19.1
     skipRange: '>=1.0.0 <1.19.0'
+  - name: openshift-gitops-operator.v1.19.3
+    replaces: openshift-gitops-operator.v1.19.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1147,5 +1149,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2bc42a4808fc4a7cdcae41851a92608357edeab3e60c70c47b0bf2b97eeae162
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -1114,6 +1114,8 @@ entries:
   - name: openshift-gitops-operator.v1.19.2
     replaces: openshift-gitops-operator.v1.19.1
     skipRange: '>=1.0.0 <1.19.0'
+  - name: openshift-gitops-operator.v1.19.3
+    replaces: openshift-gitops-operator.v1.19.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1147,5 +1149,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:7c013b84398fcf4234f8e7b768bcb0dad47e4dea57f216d3c30bc55191105da4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c062948b8b4db332117e81be790b823ae41f3a83848395966227b07b4ac57a03
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2bc42a4808fc4a7cdcae41851a92608357edeab3e60c70c47b0bf2b97eeae162
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -67,6 +67,10 @@ channels:
         replaces: openshift-gitops-operator.v1.19.1
         skipRange: '>=1.0.0 <1.19.0'
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:00e866aafc577f084f3bc233becd9dac15404831189a122c362112791411a796
+      - name: openshift-gitops-operator.v1.19.3
+        replaces: openshift-gitops-operator.v1.19.2
+        skipRange: ''
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2bc42a4808fc4a7cdcae41851a92608357edeab3e60c70c47b0bf2b97eeae162
   - name: gitops-1.20
     versions:
       - name: openshift-gitops-operator.v1.20.0


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.19.3-1 <br>**Timestamp:** 20260413-083146 <br><br>Automatically generated by GitHub Actions.