### PR TITLE
chore(release-candidate): update catalog for build v1.20.2-5

### DIFF
--- a/catalog/v4.12/template.yaml
+++ b/catalog/v4.12/template.yaml
@@ -1296,8 +1296,8 @@ entries:
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ffa6c06bce9ed47ed53225fac8fc849e3c5977fd8509762953de03cace83ed3c
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:4bf2b16b22955b02e15155ac8531b0edf09433d39470a9223f928c00771fa373
-- schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e8a5213454b71e952de52bd448d5f52e6de868821a23c15b71c2b46809bdd570
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
 schema: olm.template.basic
 

--- a/catalog/v4.13/template.yaml
+++ b/catalog/v4.13/template.yaml
@@ -1148,8 +1148,8 @@ entries:
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ffa6c06bce9ed47ed53225fac8fc849e3c5977fd8509762953de03cace83ed3c
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:4bf2b16b22955b02e15155ac8531b0edf09433d39470a9223f928c00771fa373
-- schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e8a5213454b71e952de52bd448d5f52e6de868821a23c15b71c2b46809bdd570
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
 schema: olm.template.basic
 

--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -1148,8 +1148,8 @@ entries:
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ffa6c06bce9ed47ed53225fac8fc849e3c5977fd8509762953de03cace83ed3c
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:4bf2b16b22955b02e15155ac8531b0edf09433d39470a9223f928c00771fa373
-- schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e8a5213454b71e952de52bd448d5f52e6de868821a23c15b71c2b46809bdd570
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -1148,8 +1148,8 @@ entries:
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ffa6c06bce9ed47ed53225fac8fc849e3c5977fd8509762953de03cace83ed3c
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:4bf2b16b22955b02e15155ac8531b0edf09433d39470a9223f928c00771fa373
-- schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e8a5213454b71e952de52bd448d5f52e6de868821a23c15b71c2b46809bdd570
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -1148,8 +1148,8 @@ entries:
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ffa6c06bce9ed47ed53225fac8fc849e3c5977fd8509762953de03cace83ed3c
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:4bf2b16b22955b02e15155ac8531b0edf09433d39470a9223f928c00771fa373
-- schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e8a5213454b71e952de52bd448d5f52e6de868821a23c15b71c2b46809bdd570
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -1148,8 +1148,8 @@ entries:
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ffa6c06bce9ed47ed53225fac8fc849e3c5977fd8509762953de03cace83ed3c
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:4bf2b16b22955b02e15155ac8531b0edf09433d39470a9223f928c00771fa373
-- schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e8a5213454b71e952de52bd448d5f52e6de868821a23c15b71c2b46809bdd570
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -1148,8 +1148,8 @@ entries:
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ffa6c06bce9ed47ed53225fac8fc849e3c5977fd8509762953de03cace83ed3c
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:4bf2b16b22955b02e15155ac8531b0edf09433d39470a9223f928c00771fa373
-- schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e8a5213454b71e952de52bd448d5f52e6de868821a23c15b71c2b46809bdd570
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -1148,8 +1148,8 @@ entries:
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ffa6c06bce9ed47ed53225fac8fc849e3c5977fd8509762953de03cace83ed3c
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:4bf2b16b22955b02e15155ac8531b0edf09433d39470a9223f928c00771fa373
-- schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e8a5213454b71e952de52bd448d5f52e6de868821a23c15b71c2b46809bdd570
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -1148,8 +1148,8 @@ entries:
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ffa6c06bce9ed47ed53225fac8fc849e3c5977fd8509762953de03cace83ed3c
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:4bf2b16b22955b02e15155ac8531b0edf09433d39470a9223f928c00771fa373
-- schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e8a5213454b71e952de52bd448d5f52e6de868821a23c15b71c2b46809bdd570
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
 schema: olm.template.basic
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -1148,8 +1148,8 @@ entries:
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ffa6c06bce9ed47ed53225fac8fc849e3c5977fd8509762953de03cace83ed3c
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:4bf2b16b22955b02e15155ac8531b0edf09433d39470a9223f928c00771fa373
-- schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e8a5213454b71e952de52bd448d5f52e6de868821a23c15b71c2b46809bdd570
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -1148,8 +1148,8 @@ entries:
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ffa6c06bce9ed47ed53225fac8fc849e3c5977fd8509762953de03cace83ed3c
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:4bf2b16b22955b02e15155ac8531b0edf09433d39470a9223f928c00771fa373
-- schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e8a5213454b71e952de52bd448d5f52e6de868821a23c15b71c2b46809bdd570
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -84,4 +84,4 @@ channels:
       - name: openshift-gitops-operator.v1.20.2
         replaces: openshift-gitops-operator.v1.20.1
         skipRange: ''
-        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:4bf2b16b22955b02e15155ac8531b0edf09433d39470a9223f928c00771fa373
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.20.2-5 <br>**Timestamp:** 20260421-125318 <br><br>Automatically generated by GitHub Actions.