### PR TITLE
chore(release-candidate): update catalog for build v1.20.3-0

### DIFF
--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -888,6 +888,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1141,6 +1143,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1151,5 +1155,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:9d16d9f172618c8f03b2b5b930220761ed97faa90ebd38f570d60bed5216b433
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e5555828cf2f97969c5a2243fc6fb2f0935bd8faefdd5b08e89c2b07ffb66362
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -888,6 +888,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1141,6 +1143,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1151,5 +1155,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:9d16d9f172618c8f03b2b5b930220761ed97faa90ebd38f570d60bed5216b433
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e5555828cf2f97969c5a2243fc6fb2f0935bd8faefdd5b08e89c2b07ffb66362
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -888,6 +888,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1141,6 +1143,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1151,5 +1155,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:9d16d9f172618c8f03b2b5b930220761ed97faa90ebd38f570d60bed5216b433
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e5555828cf2f97969c5a2243fc6fb2f0935bd8faefdd5b08e89c2b07ffb66362
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -888,6 +888,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1141,6 +1143,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1151,5 +1155,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:9d16d9f172618c8f03b2b5b930220761ed97faa90ebd38f570d60bed5216b433
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e5555828cf2f97969c5a2243fc6fb2f0935bd8faefdd5b08e89c2b07ffb66362
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -888,6 +888,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1141,6 +1143,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1151,5 +1155,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:9d16d9f172618c8f03b2b5b930220761ed97faa90ebd38f570d60bed5216b433
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e5555828cf2f97969c5a2243fc6fb2f0935bd8faefdd5b08e89c2b07ffb66362
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -888,6 +888,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1141,6 +1143,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1151,5 +1155,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:9d16d9f172618c8f03b2b5b930220761ed97faa90ebd38f570d60bed5216b433
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e5555828cf2f97969c5a2243fc6fb2f0935bd8faefdd5b08e89c2b07ffb66362
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -888,6 +888,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1141,6 +1143,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1151,5 +1155,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:9d16d9f172618c8f03b2b5b930220761ed97faa90ebd38f570d60bed5216b433
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e5555828cf2f97969c5a2243fc6fb2f0935bd8faefdd5b08e89c2b07ffb66362
 schema: olm.template.basic
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -888,6 +888,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1141,6 +1143,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1151,5 +1155,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:9d16d9f172618c8f03b2b5b930220761ed97faa90ebd38f570d60bed5216b433
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e5555828cf2f97969c5a2243fc6fb2f0935bd8faefdd5b08e89c2b07ffb66362
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -888,6 +888,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1141,6 +1143,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.0
   - name: openshift-gitops-operator.v1.20.2
     replaces: openshift-gitops-operator.v1.20.1
+  - name: openshift-gitops-operator.v1.20.3
+    replaces: openshift-gitops-operator.v1.20.2
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1151,5 +1155,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:9d16d9f172618c8f03b2b5b930220761ed97faa90ebd38f570d60bed5216b433
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e5555828cf2f97969c5a2243fc6fb2f0935bd8faefdd5b08e89c2b07ffb66362
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -59,3 +59,7 @@ channels:
         replaces: openshift-gitops-operator.v1.20.1
         skipRange: ''
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:247a54db35e184702d9c1d6f83cd9e3669f8aae48bd0eeaecdbeeda6176c525f
+      - name: openshift-gitops-operator.v1.20.3
+        replaces: openshift-gitops-operator.v1.20.2
+        skipRange: ''
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e5555828cf2f97969c5a2243fc6fb2f0935bd8faefdd5b08e89c2b07ffb66362


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.20.3-0 <br>**Timestamp:** 20260423-054454 <br><br>Automatically generated by GitHub Actions.