### PR TITLE
chore(release-candidate): update catalog for build v1.19.4-0

### DIFF
--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -1120,6 +1120,8 @@ entries:
     skipRange: '>=1.0.0 <1.19.0'
   - name: openshift-gitops-operator.v1.19.3
     replaces: openshift-gitops-operator.v1.19.2
+  - name: openshift-gitops-operator.v1.19.4
+    replaces: openshift-gitops-operator.v1.19.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1161,5 +1163,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:407b2310e342ddde5229624bac66ec364840c368f36e4831502a8ce4e45d972b
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:198b546729327c8cec370ca3e544507a73c4fed95a111c3f0d1fcee2affdf976
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -1120,6 +1120,8 @@ entries:
     skipRange: '>=1.0.0 <1.19.0'
   - name: openshift-gitops-operator.v1.19.3
     replaces: openshift-gitops-operator.v1.19.2
+  - name: openshift-gitops-operator.v1.19.4
+    replaces: openshift-gitops-operator.v1.19.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1161,5 +1163,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:407b2310e342ddde5229624bac66ec364840c368f36e4831502a8ce4e45d972b
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:198b546729327c8cec370ca3e544507a73c4fed95a111c3f0d1fcee2affdf976
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -1120,6 +1120,8 @@ entries:
     skipRange: '>=1.0.0 <1.19.0'
   - name: openshift-gitops-operator.v1.19.3
     replaces: openshift-gitops-operator.v1.19.2
+  - name: openshift-gitops-operator.v1.19.4
+    replaces: openshift-gitops-operator.v1.19.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1161,5 +1163,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:407b2310e342ddde5229624bac66ec364840c368f36e4831502a8ce4e45d972b
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:198b546729327c8cec370ca3e544507a73c4fed95a111c3f0d1fcee2affdf976
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -1120,6 +1120,8 @@ entries:
     skipRange: '>=1.0.0 <1.19.0'
   - name: openshift-gitops-operator.v1.19.3
     replaces: openshift-gitops-operator.v1.19.2
+  - name: openshift-gitops-operator.v1.19.4
+    replaces: openshift-gitops-operator.v1.19.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1161,5 +1163,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:407b2310e342ddde5229624bac66ec364840c368f36e4831502a8ce4e45d972b
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:198b546729327c8cec370ca3e544507a73c4fed95a111c3f0d1fcee2affdf976
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -1120,6 +1120,8 @@ entries:
     skipRange: '>=1.0.0 <1.19.0'
   - name: openshift-gitops-operator.v1.19.3
     replaces: openshift-gitops-operator.v1.19.2
+  - name: openshift-gitops-operator.v1.19.4
+    replaces: openshift-gitops-operator.v1.19.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1161,5 +1163,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:407b2310e342ddde5229624bac66ec364840c368f36e4831502a8ce4e45d972b
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:198b546729327c8cec370ca3e544507a73c4fed95a111c3f0d1fcee2affdf976
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -1120,6 +1120,8 @@ entries:
     skipRange: '>=1.0.0 <1.19.0'
   - name: openshift-gitops-operator.v1.19.3
     replaces: openshift-gitops-operator.v1.19.2
+  - name: openshift-gitops-operator.v1.19.4
+    replaces: openshift-gitops-operator.v1.19.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1161,5 +1163,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:407b2310e342ddde5229624bac66ec364840c368f36e4831502a8ce4e45d972b
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:198b546729327c8cec370ca3e544507a73c4fed95a111c3f0d1fcee2affdf976
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -1120,6 +1120,8 @@ entries:
     skipRange: '>=1.0.0 <1.19.0'
   - name: openshift-gitops-operator.v1.19.3
     replaces: openshift-gitops-operator.v1.19.2
+  - name: openshift-gitops-operator.v1.19.4
+    replaces: openshift-gitops-operator.v1.19.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1161,5 +1163,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:407b2310e342ddde5229624bac66ec364840c368f36e4831502a8ce4e45d972b
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:198b546729327c8cec370ca3e544507a73c4fed95a111c3f0d1fcee2affdf976
 schema: olm.template.basic
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -1120,6 +1120,8 @@ entries:
     skipRange: '>=1.0.0 <1.19.0'
   - name: openshift-gitops-operator.v1.19.3
     replaces: openshift-gitops-operator.v1.19.2
+  - name: openshift-gitops-operator.v1.19.4
+    replaces: openshift-gitops-operator.v1.19.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1161,5 +1163,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:407b2310e342ddde5229624bac66ec364840c368f36e4831502a8ce4e45d972b
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:198b546729327c8cec370ca3e544507a73c4fed95a111c3f0d1fcee2affdf976
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -1120,6 +1120,8 @@ entries:
     skipRange: '>=1.0.0 <1.19.0'
   - name: openshift-gitops-operator.v1.19.3
     replaces: openshift-gitops-operator.v1.19.2
+  - name: openshift-gitops-operator.v1.19.4
+    replaces: openshift-gitops-operator.v1.19.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1161,5 +1163,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:407b2310e342ddde5229624bac66ec364840c368f36e4831502a8ce4e45d972b
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:198b546729327c8cec370ca3e544507a73c4fed95a111c3f0d1fcee2affdf976
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -49,6 +49,10 @@ channels:
         replaces: openshift-gitops-operator.v1.19.2
         skipRange: ''
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:9d16d9f172618c8f03b2b5b930220761ed97faa90ebd38f570d60bed5216b433
+      - name: openshift-gitops-operator.v1.19.4
+        replaces: openshift-gitops-operator.v1.19.3
+        skipRange: ''
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:198b546729327c8cec370ca3e544507a73c4fed95a111c3f0d1fcee2affdf976
   - name: gitops-1.20
     versions:
       - name: openshift-gitops-operator.v1.20.0


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.19.4-0 <br>**Timestamp:** 20260519-074205 <br><br>Automatically generated by GitHub Actions.