### PR TITLE
chore(release-candidate): update catalog for build v1.20.4-2

### DIFF
--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -890,6 +890,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1149,6 +1151,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1165,5 +1169,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -890,6 +890,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1149,6 +1151,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1165,5 +1169,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -890,6 +890,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1149,6 +1151,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1165,5 +1169,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -890,6 +890,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1149,6 +1151,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1165,5 +1169,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -890,6 +890,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1149,6 +1151,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1165,5 +1169,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -890,6 +890,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1149,6 +1151,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1165,5 +1169,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -890,6 +890,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1149,6 +1151,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1165,5 +1169,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
 schema: olm.template.basic
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -890,6 +890,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1149,6 +1151,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1165,5 +1169,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -890,6 +890,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1149,6 +1151,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.1
   - name: openshift-gitops-operator.v1.20.3
     replaces: openshift-gitops-operator.v1.20.2
+  - name: openshift-gitops-operator.v1.20.4
+    replaces: openshift-gitops-operator.v1.20.3
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1165,5 +1169,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:cf81d0157a9065d04ab880096a613e0400c4bcda36f01eeb94879389cec30159
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -71,3 +71,7 @@ channels:
         replaces: openshift-gitops-operator.v1.20.2
         skipRange: ''
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:407b2310e342ddde5229624bac66ec364840c368f36e4831502a8ce4e45d972b
+      - name: openshift-gitops-operator.v1.20.4
+        replaces: openshift-gitops-operator.v1.20.3
+        skipRange: ''
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.20.4-2 <br>**Timestamp:** 20260520-164917 <br><br>Automatically generated by GitHub Actions.