### PR TITLE
chore(release-candidate): update catalog for build v1.21.0-1

### DIFF
--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -892,6 +892,9 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1171,5 +1174,14 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
+- name: gitops-1.21
+  package: openshift-gitops-operator
+  schema: olm.channel
+  entries:
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -892,6 +892,9 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1171,5 +1174,14 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
+- name: gitops-1.21
+  package: openshift-gitops-operator
+  schema: olm.channel
+  entries:
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -892,6 +892,9 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1171,5 +1174,14 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
+- name: gitops-1.21
+  package: openshift-gitops-operator
+  schema: olm.channel
+  entries:
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -892,6 +892,9 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1171,5 +1174,14 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
+- name: gitops-1.21
+  package: openshift-gitops-operator
+  schema: olm.channel
+  entries:
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -892,6 +892,9 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1171,5 +1174,14 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
+- name: gitops-1.21
+  package: openshift-gitops-operator
+  schema: olm.channel
+  entries:
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -892,6 +892,9 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1171,5 +1174,14 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
+- name: gitops-1.21
+  package: openshift-gitops-operator
+  schema: olm.channel
+  entries:
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -892,6 +892,9 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1171,5 +1174,14 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
+- name: gitops-1.21
+  package: openshift-gitops-operator
+  schema: olm.channel
+  entries:
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
 schema: olm.template.basic
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -892,6 +892,9 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1171,5 +1174,14 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
+- name: gitops-1.21
+  package: openshift-gitops-operator
+  schema: olm.channel
+  entries:
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -892,6 +892,9 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1171,5 +1174,14 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
+- name: gitops-1.21
+  package: openshift-gitops-operator
+  schema: olm.channel
+  entries:
+  - name: openshift-gitops-operator.v1.21.0
+    replaces: openshift-gitops-operator.v1.20.4
+    skipRange: '>=1.0.0 <1.21.0'
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -75,3 +75,9 @@ channels:
         replaces: openshift-gitops-operator.v1.20.3
         skipRange: ''
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
+  - name: gitops-1.21
+    versions:
+      - name: openshift-gitops-operator.v1.21.0
+        replaces: openshift-gitops-operator.v1.20.4
+        skipRange: '>=1.0.0 <1.21.0'
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.21.0-1 <br>**Timestamp:** 20260603-035920 <br><br>Automatically generated by GitHub Actions.