### PR TITLE
chore(release-candidate): update catalog for build v1.21.0-2

### DIFF
--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:6ae64d35b0e7e157606d8bbfbd3b3a5041f8742d2092b4356acdce066330c20b
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:6ae64d35b0e7e157606d8bbfbd3b3a5041f8742d2092b4356acdce066330c20b
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:6ae64d35b0e7e157606d8bbfbd3b3a5041f8742d2092b4356acdce066330c20b
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:6ae64d35b0e7e157606d8bbfbd3b3a5041f8742d2092b4356acdce066330c20b
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:6ae64d35b0e7e157606d8bbfbd3b3a5041f8742d2092b4356acdce066330c20b
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:6ae64d35b0e7e157606d8bbfbd3b3a5041f8742d2092b4356acdce066330c20b
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:6ae64d35b0e7e157606d8bbfbd3b3a5041f8742d2092b4356acdce066330c20b
 schema: olm.template.basic
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:6ae64d35b0e7e157606d8bbfbd3b3a5041f8742d2092b4356acdce066330c20b
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:6ae64d35b0e7e157606d8bbfbd3b3a5041f8742d2092b4356acdce066330c20b
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -80,4 +80,4 @@ channels:
       - name: openshift-gitops-operator.v1.21.0
         replaces: openshift-gitops-operator.v1.20.4
         skipRange: '>=1.0.0 <1.21.0'
-        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:814fd963ab4b8a4a3ddd455d4333562434148ad594d6c1164e124c0b692e1c05
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:6ae64d35b0e7e157606d8bbfbd3b3a5041f8742d2092b4356acdce066330c20b


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.21.0-2 <br>**Timestamp:** 20260604-062022 <br><br>Automatically generated by GitHub Actions.