### PR TITLE
chore(release-candidate): update catalog for build v1.21.0-4

### DIFF
--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5dd8f9519849e1865b3e242cafcdb3a84117a5d44be57ff4f5e70f2205e12d21
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:bf87007daca8443b9c32278665b519bc28b9fbf6844cd69ee9baa6335bed5ce0
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5dd8f9519849e1865b3e242cafcdb3a84117a5d44be57ff4f5e70f2205e12d21
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:bf87007daca8443b9c32278665b519bc28b9fbf6844cd69ee9baa6335bed5ce0
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5dd8f9519849e1865b3e242cafcdb3a84117a5d44be57ff4f5e70f2205e12d21
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:bf87007daca8443b9c32278665b519bc28b9fbf6844cd69ee9baa6335bed5ce0
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5dd8f9519849e1865b3e242cafcdb3a84117a5d44be57ff4f5e70f2205e12d21
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:bf87007daca8443b9c32278665b519bc28b9fbf6844cd69ee9baa6335bed5ce0
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5dd8f9519849e1865b3e242cafcdb3a84117a5d44be57ff4f5e70f2205e12d21
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:bf87007daca8443b9c32278665b519bc28b9fbf6844cd69ee9baa6335bed5ce0
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5dd8f9519849e1865b3e242cafcdb3a84117a5d44be57ff4f5e70f2205e12d21
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:bf87007daca8443b9c32278665b519bc28b9fbf6844cd69ee9baa6335bed5ce0
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5dd8f9519849e1865b3e242cafcdb3a84117a5d44be57ff4f5e70f2205e12d21
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:bf87007daca8443b9c32278665b519bc28b9fbf6844cd69ee9baa6335bed5ce0
 schema: olm.template.basic
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5dd8f9519849e1865b3e242cafcdb3a84117a5d44be57ff4f5e70f2205e12d21
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:bf87007daca8443b9c32278665b519bc28b9fbf6844cd69ee9baa6335bed5ce0
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -1182,6 +1182,6 @@ entries:
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
-  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5dd8f9519849e1865b3e242cafcdb3a84117a5d44be57ff4f5e70f2205e12d21
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:bf87007daca8443b9c32278665b519bc28b9fbf6844cd69ee9baa6335bed5ce0
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -80,4 +80,4 @@ channels:
       - name: openshift-gitops-operator.v1.21.0
         replaces: openshift-gitops-operator.v1.20.4
         skipRange: '>=1.0.0 <1.21.0'
-        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5dd8f9519849e1865b3e242cafcdb3a84117a5d44be57ff4f5e70f2205e12d21
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:bf87007daca8443b9c32278665b519bc28b9fbf6844cd69ee9baa6335bed5ce0


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.21.0-4 <br>**Timestamp:** 20260611-065129 <br><br>Automatically generated by GitHub Actions.