### PR TITLE
chore(release-candidate): update catalog for build v1.20.5-0

### DIFF
--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -1156,6 +1156,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e39504bd62ecbb106d4817eb18d9eafa7035eeb49b08f723a887969eeb2b38b7
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -1156,6 +1156,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e39504bd62ecbb106d4817eb18d9eafa7035eeb49b08f723a887969eeb2b38b7
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -1156,6 +1156,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e39504bd62ecbb106d4817eb18d9eafa7035eeb49b08f723a887969eeb2b38b7
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -1156,6 +1156,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e39504bd62ecbb106d4817eb18d9eafa7035eeb49b08f723a887969eeb2b38b7
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -1156,6 +1156,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e39504bd62ecbb106d4817eb18d9eafa7035eeb49b08f723a887969eeb2b38b7
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -1156,6 +1156,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e39504bd62ecbb106d4817eb18d9eafa7035eeb49b08f723a887969eeb2b38b7
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -1156,6 +1156,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e39504bd62ecbb106d4817eb18d9eafa7035eeb49b08f723a887969eeb2b38b7
 schema: olm.template.basic
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -1156,6 +1156,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e39504bd62ecbb106d4817eb18d9eafa7035eeb49b08f723a887969eeb2b38b7
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -1156,6 +1156,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e39504bd62ecbb106d4817eb18d9eafa7035eeb49b08f723a887969eeb2b38b7
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -75,6 +75,10 @@ channels:
         replaces: openshift-gitops-operator.v1.20.3
         skipRange: ''
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
+      - name: openshift-gitops-operator.v1.20.5
+        replaces: openshift-gitops-operator.v1.20.4
+        skipRange: ''
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:e39504bd62ecbb106d4817eb18d9eafa7035eeb49b08f723a887969eeb2b38b7
   - name: gitops-1.21
     versions:
       - name: openshift-gitops-operator.v1.21.0


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.20.5-0 <br>**Timestamp:** 20260623-062351 <br><br>Automatically generated by GitHub Actions.