### PR TITLE
chore(release-candidate): update catalog for build v1.19.5-1

### DIFF
--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -1127,6 +1127,8 @@ entries:
     replaces: openshift-gitops-operator.v1.19.2
   - name: openshift-gitops-operator.v1.19.4
     replaces: openshift-gitops-operator.v1.19.3
+  - name: openshift-gitops-operator.v1.19.5
+    replaces: openshift-gitops-operator.v1.19.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -1127,6 +1127,8 @@ entries:
     replaces: openshift-gitops-operator.v1.19.2
   - name: openshift-gitops-operator.v1.19.4
     replaces: openshift-gitops-operator.v1.19.3
+  - name: openshift-gitops-operator.v1.19.5
+    replaces: openshift-gitops-operator.v1.19.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -1127,6 +1127,8 @@ entries:
     replaces: openshift-gitops-operator.v1.19.2
   - name: openshift-gitops-operator.v1.19.4
     replaces: openshift-gitops-operator.v1.19.3
+  - name: openshift-gitops-operator.v1.19.5
+    replaces: openshift-gitops-operator.v1.19.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -1127,6 +1127,8 @@ entries:
     replaces: openshift-gitops-operator.v1.19.2
   - name: openshift-gitops-operator.v1.19.4
     replaces: openshift-gitops-operator.v1.19.3
+  - name: openshift-gitops-operator.v1.19.5
+    replaces: openshift-gitops-operator.v1.19.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -1127,6 +1127,8 @@ entries:
     replaces: openshift-gitops-operator.v1.19.2
   - name: openshift-gitops-operator.v1.19.4
     replaces: openshift-gitops-operator.v1.19.3
+  - name: openshift-gitops-operator.v1.19.5
+    replaces: openshift-gitops-operator.v1.19.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -1127,6 +1127,8 @@ entries:
     replaces: openshift-gitops-operator.v1.19.2
   - name: openshift-gitops-operator.v1.19.4
     replaces: openshift-gitops-operator.v1.19.3
+  - name: openshift-gitops-operator.v1.19.5
+    replaces: openshift-gitops-operator.v1.19.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -1127,6 +1127,8 @@ entries:
     replaces: openshift-gitops-operator.v1.19.2
   - name: openshift-gitops-operator.v1.19.4
     replaces: openshift-gitops-operator.v1.19.3
+  - name: openshift-gitops-operator.v1.19.5
+    replaces: openshift-gitops-operator.v1.19.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 schema: olm.template.basic
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -1127,6 +1127,8 @@ entries:
     replaces: openshift-gitops-operator.v1.19.2
   - name: openshift-gitops-operator.v1.19.4
     replaces: openshift-gitops-operator.v1.19.3
+  - name: openshift-gitops-operator.v1.19.5
+    replaces: openshift-gitops-operator.v1.19.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -1127,6 +1127,8 @@ entries:
     replaces: openshift-gitops-operator.v1.19.2
   - name: openshift-gitops-operator.v1.19.4
     replaces: openshift-gitops-operator.v1.19.3
+  - name: openshift-gitops-operator.v1.19.5
+    replaces: openshift-gitops-operator.v1.19.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1183,5 +1185,7 @@ entries:
     skipRange: '>=1.0.0 <1.21.0'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -53,6 +53,10 @@ channels:
         replaces: openshift-gitops-operator.v1.19.3
         skipRange: ''
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:c41e74df4743068317457d2db0209e08be023758add611f49769900e58299a93
+      - name: openshift-gitops-operator.v1.19.5
+        replaces: openshift-gitops-operator.v1.19.4
+        skipRange: ''
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
   - name: gitops-1.20
     versions:
       - name: openshift-gitops-operator.v1.20.0


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.19.5-1 <br>**Timestamp:** 20260624-152236 <br><br>Automatically generated by GitHub Actions.