### PR TITLE
chore(release-candidate): update catalog for build v1.20.5-1

### DIFF
--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -1161,6 +1161,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1195,5 +1197,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ab73efa5510b25fa420b34d3aa52b4c118c9efb58fde42edc473864b2f2f8529
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -1161,6 +1161,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1195,5 +1197,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ab73efa5510b25fa420b34d3aa52b4c118c9efb58fde42edc473864b2f2f8529
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -1161,6 +1161,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1195,5 +1197,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ab73efa5510b25fa420b34d3aa52b4c118c9efb58fde42edc473864b2f2f8529
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -1161,6 +1161,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1195,5 +1197,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ab73efa5510b25fa420b34d3aa52b4c118c9efb58fde42edc473864b2f2f8529
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -1161,6 +1161,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1195,5 +1197,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ab73efa5510b25fa420b34d3aa52b4c118c9efb58fde42edc473864b2f2f8529
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -1161,6 +1161,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1195,5 +1197,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ab73efa5510b25fa420b34d3aa52b4c118c9efb58fde42edc473864b2f2f8529
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -1161,6 +1161,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1195,5 +1197,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ab73efa5510b25fa420b34d3aa52b4c118c9efb58fde42edc473864b2f2f8529
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 schema: olm.template.basic
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -1161,6 +1161,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1195,5 +1197,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ab73efa5510b25fa420b34d3aa52b4c118c9efb58fde42edc473864b2f2f8529
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -1161,6 +1161,8 @@ entries:
     replaces: openshift-gitops-operator.v1.20.2
   - name: openshift-gitops-operator.v1.20.4
     replaces: openshift-gitops-operator.v1.20.3
+  - name: openshift-gitops-operator.v1.20.5
+    replaces: openshift-gitops-operator.v1.20.4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1195,5 +1197,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ab73efa5510b25fa420b34d3aa52b4c118c9efb58fde42edc473864b2f2f8529
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -79,6 +79,10 @@ channels:
         replaces: openshift-gitops-operator.v1.20.3
         skipRange: ''
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:b89210f76c58360210437f48dbde51d298ab1eb30cd2b77fb93c0e84dc8740c1
+      - name: openshift-gitops-operator.v1.20.5
+        replaces: openshift-gitops-operator.v1.20.4
+        skipRange: ''
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
   - name: gitops-1.21
     versions:
       - name: openshift-gitops-operator.v1.21.0


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.20.5-1 <br>**Timestamp:** 20260626-041213 <br><br>Automatically generated by GitHub Actions.