### PR TITLE
chore(release-candidate): update catalog for build v1.19.6-1

### DIFF
--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -1132,6 +1132,9 @@ entries:
     replaces: openshift-gitops-operator.v1.19.3
   - name: openshift-gitops-operator.v1.19.5
     replaces: openshift-gitops-operator.v1.19.4
+  - name: openshift-gitops-operator.v1.19.6
+    replaces: openshift-gitops-operator.v1.19.5
+    skipRange: '>=1.19.0 <1.19.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1199,5 +1202,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:98489356a3f11dc30058cd04bef773b6d22abff9c5fb24afa57cafa99a2bb005
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -1132,6 +1132,9 @@ entries:
     replaces: openshift-gitops-operator.v1.19.3
   - name: openshift-gitops-operator.v1.19.5
     replaces: openshift-gitops-operator.v1.19.4
+  - name: openshift-gitops-operator.v1.19.6
+    replaces: openshift-gitops-operator.v1.19.5
+    skipRange: '>=1.19.0 <1.19.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1199,5 +1202,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:98489356a3f11dc30058cd04bef773b6d22abff9c5fb24afa57cafa99a2bb005
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -1132,6 +1132,9 @@ entries:
     replaces: openshift-gitops-operator.v1.19.3
   - name: openshift-gitops-operator.v1.19.5
     replaces: openshift-gitops-operator.v1.19.4
+  - name: openshift-gitops-operator.v1.19.6
+    replaces: openshift-gitops-operator.v1.19.5
+    skipRange: '>=1.19.0 <1.19.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1199,5 +1202,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:98489356a3f11dc30058cd04bef773b6d22abff9c5fb24afa57cafa99a2bb005
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -1132,6 +1132,9 @@ entries:
     replaces: openshift-gitops-operator.v1.19.3
   - name: openshift-gitops-operator.v1.19.5
     replaces: openshift-gitops-operator.v1.19.4
+  - name: openshift-gitops-operator.v1.19.6
+    replaces: openshift-gitops-operator.v1.19.5
+    skipRange: '>=1.19.0 <1.19.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1199,5 +1202,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:98489356a3f11dc30058cd04bef773b6d22abff9c5fb24afa57cafa99a2bb005
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -1132,6 +1132,9 @@ entries:
     replaces: openshift-gitops-operator.v1.19.3
   - name: openshift-gitops-operator.v1.19.5
     replaces: openshift-gitops-operator.v1.19.4
+  - name: openshift-gitops-operator.v1.19.6
+    replaces: openshift-gitops-operator.v1.19.5
+    skipRange: '>=1.19.0 <1.19.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1199,5 +1202,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:98489356a3f11dc30058cd04bef773b6d22abff9c5fb24afa57cafa99a2bb005
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -1132,6 +1132,9 @@ entries:
     replaces: openshift-gitops-operator.v1.19.3
   - name: openshift-gitops-operator.v1.19.5
     replaces: openshift-gitops-operator.v1.19.4
+  - name: openshift-gitops-operator.v1.19.6
+    replaces: openshift-gitops-operator.v1.19.5
+    skipRange: '>=1.19.0 <1.19.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1199,5 +1202,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:98489356a3f11dc30058cd04bef773b6d22abff9c5fb24afa57cafa99a2bb005
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -1132,6 +1132,9 @@ entries:
     replaces: openshift-gitops-operator.v1.19.3
   - name: openshift-gitops-operator.v1.19.5
     replaces: openshift-gitops-operator.v1.19.4
+  - name: openshift-gitops-operator.v1.19.6
+    replaces: openshift-gitops-operator.v1.19.5
+    skipRange: '>=1.19.0 <1.19.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1199,5 +1202,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:98489356a3f11dc30058cd04bef773b6d22abff9c5fb24afa57cafa99a2bb005
 schema: olm.template.basic
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -1132,6 +1132,9 @@ entries:
     replaces: openshift-gitops-operator.v1.19.3
   - name: openshift-gitops-operator.v1.19.5
     replaces: openshift-gitops-operator.v1.19.4
+  - name: openshift-gitops-operator.v1.19.6
+    replaces: openshift-gitops-operator.v1.19.5
+    skipRange: '>=1.19.0 <1.19.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1199,5 +1202,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:98489356a3f11dc30058cd04bef773b6d22abff9c5fb24afa57cafa99a2bb005
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -1132,6 +1132,9 @@ entries:
     replaces: openshift-gitops-operator.v1.19.3
   - name: openshift-gitops-operator.v1.19.5
     replaces: openshift-gitops-operator.v1.19.4
+  - name: openshift-gitops-operator.v1.19.6
+    replaces: openshift-gitops-operator.v1.19.5
+    skipRange: '>=1.19.0 <1.19.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5e78b9e6a98218c209af1d85e60c2000172a90f178f32f06f0e3b6bc11f33cce
 - schema: olm.bundle
@@ -1199,5 +1202,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:98489356a3f11dc30058cd04bef773b6d22abff9c5fb24afa57cafa99a2bb005
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -57,6 +57,10 @@ channels:
         replaces: openshift-gitops-operator.v1.19.4
         skipRange: ''
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:22419f173ef1d31a83d226bc3b23fb283db62a9693c8f1df0a5e2fb4b3b38df4
+      - name: openshift-gitops-operator.v1.19.6
+        replaces: openshift-gitops-operator.v1.19.5
+        skipRange: '>=1.19.0 <1.19.6'
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:98489356a3f11dc30058cd04bef773b6d22abff9c5fb24afa57cafa99a2bb005
   - name: gitops-1.20
     versions:
       - name: openshift-gitops-operator.v1.20.0


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.19.6-1 <br>**Timestamp:** 20260708-043703 <br><br>Automatically generated by GitHub Actions.