### PR TITLE
chore(release-candidate): update catalog for build v1.21.2-1

### DIFF
--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1191,6 +1194,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1199,5 +1205,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3bc450a9cc146fd690dfe3291409733004b316a79a4097e82508cbac4988bf6e
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1191,6 +1194,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1199,5 +1205,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3bc450a9cc146fd690dfe3291409733004b316a79a4097e82508cbac4988bf6e
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1191,6 +1194,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1199,5 +1205,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3bc450a9cc146fd690dfe3291409733004b316a79a4097e82508cbac4988bf6e
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1191,6 +1194,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1199,5 +1205,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3bc450a9cc146fd690dfe3291409733004b316a79a4097e82508cbac4988bf6e
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1191,6 +1194,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1199,5 +1205,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3bc450a9cc146fd690dfe3291409733004b316a79a4097e82508cbac4988bf6e
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1191,6 +1194,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1199,5 +1205,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3bc450a9cc146fd690dfe3291409733004b316a79a4097e82508cbac4988bf6e
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1191,6 +1194,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1199,5 +1205,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3bc450a9cc146fd690dfe3291409733004b316a79a4097e82508cbac4988bf6e
 schema: olm.template.basic
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1191,6 +1194,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1199,5 +1205,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3bc450a9cc146fd690dfe3291409733004b316a79a4097e82508cbac4988bf6e
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1191,6 +1194,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1199,5 +1205,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3bc450a9cc146fd690dfe3291409733004b316a79a4097e82508cbac4988bf6e
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -93,3 +93,7 @@ channels:
         replaces: openshift-gitops-operator.v1.21.0
         skipRange: '>=1.21.0 <1.21.1'
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+      - name: openshift-gitops-operator.v1.21.2
+        replaces: openshift-gitops-operator.v1.21.1
+        skipRange: '>=1.21.0 <1.21.2'
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3bc450a9cc146fd690dfe3291409733004b316a79a4097e82508cbac4988bf6e


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.21.2-1 <br>**Timestamp:** 20260708-043744 <br><br>Automatically generated by GitHub Actions.