### PR TITLE
chore(release-candidate): update catalog for build v1.20.6-2

### DIFF
--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -1180,6 +1180,9 @@ entries:
   - name: openshift-gitops-operator.v1.20.5
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.20.0 <1.20.5'
+  - name: openshift-gitops-operator.v1.20.6
+    replaces: openshift-gitops-operator.v1.20.5
+    skipRange: '>=1.20.0 <1.20.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1218,5 +1221,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -1180,6 +1180,9 @@ entries:
   - name: openshift-gitops-operator.v1.20.5
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.20.0 <1.20.5'
+  - name: openshift-gitops-operator.v1.20.6
+    replaces: openshift-gitops-operator.v1.20.5
+    skipRange: '>=1.20.0 <1.20.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1218,5 +1221,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -1180,6 +1180,9 @@ entries:
   - name: openshift-gitops-operator.v1.20.5
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.20.0 <1.20.5'
+  - name: openshift-gitops-operator.v1.20.6
+    replaces: openshift-gitops-operator.v1.20.5
+    skipRange: '>=1.20.0 <1.20.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1218,5 +1221,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -1180,6 +1180,9 @@ entries:
   - name: openshift-gitops-operator.v1.20.5
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.20.0 <1.20.5'
+  - name: openshift-gitops-operator.v1.20.6
+    replaces: openshift-gitops-operator.v1.20.5
+    skipRange: '>=1.20.0 <1.20.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1218,5 +1221,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -1180,6 +1180,9 @@ entries:
   - name: openshift-gitops-operator.v1.20.5
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.20.0 <1.20.5'
+  - name: openshift-gitops-operator.v1.20.6
+    replaces: openshift-gitops-operator.v1.20.5
+    skipRange: '>=1.20.0 <1.20.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1218,5 +1221,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -1180,6 +1180,9 @@ entries:
   - name: openshift-gitops-operator.v1.20.5
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.20.0 <1.20.5'
+  - name: openshift-gitops-operator.v1.20.6
+    replaces: openshift-gitops-operator.v1.20.5
+    skipRange: '>=1.20.0 <1.20.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1218,5 +1221,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -1180,6 +1180,9 @@ entries:
   - name: openshift-gitops-operator.v1.20.5
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.20.0 <1.20.5'
+  - name: openshift-gitops-operator.v1.20.6
+    replaces: openshift-gitops-operator.v1.20.5
+    skipRange: '>=1.20.0 <1.20.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1218,6 +1221,8 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
 schema: olm.template.basic
 
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -1180,6 +1180,9 @@ entries:
   - name: openshift-gitops-operator.v1.20.5
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.20.0 <1.20.5'
+  - name: openshift-gitops-operator.v1.20.6
+    replaces: openshift-gitops-operator.v1.20.5
+    skipRange: '>=1.20.0 <1.20.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1218,5 +1221,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -1180,6 +1180,9 @@ entries:
   - name: openshift-gitops-operator.v1.20.5
     replaces: openshift-gitops-operator.v1.20.4
     skipRange: '>=1.20.0 <1.20.5'
+  - name: openshift-gitops-operator.v1.20.6
+    replaces: openshift-gitops-operator.v1.20.5
+    skipRange: '>=1.20.0 <1.20.6'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:2aca0e62daad8644afb8725504ad0e20c55a7cf960841c9ec793904adedaf4fd
 - schema: olm.bundle
@@ -1218,5 +1221,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -87,6 +87,10 @@ channels:
         replaces: openshift-gitops-operator.v1.20.4
         skipRange: '>=1.20.0 <1.20.5'
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:5552180025966b3a68028a0bdb8a9437793514c1de023537f0319eb59b36ef7c
+      - name: openshift-gitops-operator.v1.20.6
+        replaces: openshift-gitops-operator.v1.20.5
+        skipRange: '>=1.20.0 <1.20.6'
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
   - name: gitops-1.21
     versions:
       - name: openshift-gitops-operator.v1.21.0


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.20.6-2 <br>**Timestamp:** 20260728-052257 <br><br>Automatically generated by GitHub Actions.