### PR TITLE
chore(release-candidate): update catalog for build v1.21.2-2

### DIFF
--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1211,6 +1214,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1223,5 +1229,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:09b7c938f1b4fd229a06051cd13df9d7656f50061027e2808b97e3ac48a5ef95
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1211,6 +1214,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1223,5 +1229,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:09b7c938f1b4fd229a06051cd13df9d7656f50061027e2808b97e3ac48a5ef95
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1211,6 +1214,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1223,5 +1229,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:09b7c938f1b4fd229a06051cd13df9d7656f50061027e2808b97e3ac48a5ef95
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1211,6 +1214,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1223,5 +1229,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:09b7c938f1b4fd229a06051cd13df9d7656f50061027e2808b97e3ac48a5ef95
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1211,6 +1214,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1223,5 +1229,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:09b7c938f1b4fd229a06051cd13df9d7656f50061027e2808b97e3ac48a5ef95
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1211,6 +1214,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1223,5 +1229,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:09b7c938f1b4fd229a06051cd13df9d7656f50061027e2808b97e3ac48a5ef95
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1211,6 +1214,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1223,6 +1229,8 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:09b7c938f1b4fd229a06051cd13df9d7656f50061027e2808b97e3ac48a5ef95
 schema: olm.template.basic
 
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1211,6 +1214,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1223,5 +1229,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:09b7c938f1b4fd229a06051cd13df9d7656f50061027e2808b97e3ac48a5ef95
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -898,6 +898,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1211,6 +1214,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.1
     replaces: openshift-gitops-operator.v1.21.0
     skipRange: '>=1.21.0 <1.21.1'
+  - name: openshift-gitops-operator.v1.21.2
+    replaces: openshift-gitops-operator.v1.21.1
+    skipRange: '>=1.21.0 <1.21.2'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1223,5 +1229,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:ba8a383b66f3115591f896740b6a408c3a9c3c4a14c9cb06fb6b0f7d0c16a506
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:30c6420e9f92bd18b77283579da4699b26a1e20d24512f8018cfb56babf8c5db
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:09b7c938f1b4fd229a06051cd13df9d7656f50061027e2808b97e3ac48a5ef95
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -101,3 +101,7 @@ channels:
         replaces: openshift-gitops-operator.v1.21.0
         skipRange: '>=1.21.0 <1.21.1'
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:43e18d5224a339cb688dfc50b733b7fb8cbdc394ba9e4eefc7988020fe75d1ca
+      - name: openshift-gitops-operator.v1.21.2
+        replaces: openshift-gitops-operator.v1.21.1
+        skipRange: '>=1.21.0 <1.21.2'
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:09b7c938f1b4fd229a06051cd13df9d7656f50061027e2808b97e3ac48a5ef95


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.21.2-2 <br>**Timestamp:** 20260729-074536 <br><br>Automatically generated by GitHub Actions.