### PR TITLE
chore(release-candidate): update catalog for build v1.21.3-1

### DIFF
--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -901,6 +901,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1217,6 +1220,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1231,5 +1237,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3c4ae828878ba4a8d8aaca97dd135df91372e8101b34d5d61b465cacc1d33be4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -901,6 +901,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1217,6 +1220,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1231,5 +1237,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3c4ae828878ba4a8d8aaca97dd135df91372e8101b34d5d61b465cacc1d33be4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -901,6 +901,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1217,6 +1220,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1231,5 +1237,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3c4ae828878ba4a8d8aaca97dd135df91372e8101b34d5d61b465cacc1d33be4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -901,6 +901,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1217,6 +1220,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1231,5 +1237,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3c4ae828878ba4a8d8aaca97dd135df91372e8101b34d5d61b465cacc1d33be4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -901,6 +901,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1217,6 +1220,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1231,5 +1237,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3c4ae828878ba4a8d8aaca97dd135df91372e8101b34d5d61b465cacc1d33be4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -901,6 +901,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1217,6 +1220,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1231,5 +1237,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3c4ae828878ba4a8d8aaca97dd135df91372e8101b34d5d61b465cacc1d33be4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -901,6 +901,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1217,6 +1220,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1231,6 +1237,8 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3c4ae828878ba4a8d8aaca97dd135df91372e8101b34d5d61b465cacc1d33be4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
 schema: olm.template.basic
 
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -901,6 +901,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1217,6 +1220,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1231,5 +1237,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3c4ae828878ba4a8d8aaca97dd135df91372e8101b34d5d61b465cacc1d33be4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -901,6 +901,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1217,6 +1220,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.2
     replaces: openshift-gitops-operator.v1.21.1
     skipRange: '>=1.21.0 <1.21.2'
+  - name: openshift-gitops-operator.v1.21.3
+    replaces: openshift-gitops-operator.v1.21.2
+    skipRange: '>=1.21.0 <1.21.3'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1231,5 +1237,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3c4ae828878ba4a8d8aaca97dd135df91372e8101b34d5d61b465cacc1d33be4
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -105,3 +105,7 @@ channels:
         replaces: openshift-gitops-operator.v1.21.1
         skipRange: '>=1.21.0 <1.21.2'
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:3c4ae828878ba4a8d8aaca97dd135df91372e8101b34d5d61b465cacc1d33be4
+      - name: openshift-gitops-operator.v1.21.3
+        replaces: openshift-gitops-operator.v1.21.2
+        skipRange: '>=1.21.0 <1.21.3'
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.21.3-1 <br>**Timestamp:** 20260813-190152 <br><br>Automatically generated by GitHub Actions.