### PR TITLE
chore(release-candidate): update catalog for build v1.21.4-0

### DIFF
--- a/catalog/v4.14/template.yaml
+++ b/catalog/v4.14/template.yaml
@@ -904,6 +904,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1223,6 +1226,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1239,5 +1245,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:1b321ea53ae3c68a07082e33b390c12d6f46cdc05295b576c68e69f530785200
 schema: olm.template.basic
 

--- a/catalog/v4.15/template.yaml
+++ b/catalog/v4.15/template.yaml
@@ -904,6 +904,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1223,6 +1226,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1239,5 +1245,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:1b321ea53ae3c68a07082e33b390c12d6f46cdc05295b576c68e69f530785200
 schema: olm.template.basic
 

--- a/catalog/v4.16/template.yaml
+++ b/catalog/v4.16/template.yaml
@@ -904,6 +904,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1223,6 +1226,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1239,5 +1245,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:1b321ea53ae3c68a07082e33b390c12d6f46cdc05295b576c68e69f530785200
 schema: olm.template.basic
 

--- a/catalog/v4.17/template.yaml
+++ b/catalog/v4.17/template.yaml
@@ -904,6 +904,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1223,6 +1226,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1239,5 +1245,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:1b321ea53ae3c68a07082e33b390c12d6f46cdc05295b576c68e69f530785200
 schema: olm.template.basic
 

--- a/catalog/v4.18/template.yaml
+++ b/catalog/v4.18/template.yaml
@@ -904,6 +904,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1223,6 +1226,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1239,5 +1245,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:1b321ea53ae3c68a07082e33b390c12d6f46cdc05295b576c68e69f530785200
 schema: olm.template.basic
 

--- a/catalog/v4.19/template.yaml
+++ b/catalog/v4.19/template.yaml
@@ -904,6 +904,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1223,6 +1226,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1239,5 +1245,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:1b321ea53ae3c68a07082e33b390c12d6f46cdc05295b576c68e69f530785200
 schema: olm.template.basic
 

--- a/catalog/v4.20/template.yaml
+++ b/catalog/v4.20/template.yaml
@@ -904,6 +904,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1223,6 +1226,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1239,6 +1245,8 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:1b321ea53ae3c68a07082e33b390c12d6f46cdc05295b576c68e69f530785200
 schema: olm.template.basic
 
 

--- a/catalog/v4.21/template.yaml
+++ b/catalog/v4.21/template.yaml
@@ -904,6 +904,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1223,6 +1226,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1239,5 +1245,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:1b321ea53ae3c68a07082e33b390c12d6f46cdc05295b576c68e69f530785200
 schema: olm.template.basic
 

--- a/catalog/v4.22/template.yaml
+++ b/catalog/v4.22/template.yaml
@@ -904,6 +904,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
   name: latest
   package: openshift-gitops-operator
   schema: olm.channel
@@ -1223,6 +1226,9 @@ entries:
   - name: openshift-gitops-operator.v1.21.3
     replaces: openshift-gitops-operator.v1.21.2
     skipRange: '>=1.21.0 <1.21.3'
+  - name: openshift-gitops-operator.v1.21.4
+    replaces: openshift-gitops-operator.v1.21.3
+    skipRange: '>=1.21.0 <1.21.4'
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fc5565b546154b179739109ab730b1caf4e8d57632d1090720d08dae602fbee5
 - schema: olm.bundle
@@ -1239,5 +1245,7 @@ entries:
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:0aea43abfd0702c07cf70541bc46fe742b0742c9f43641134e2163eaca8f4b5c
 - schema: olm.bundle
   image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
+- schema: olm.bundle
+  image: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:1b321ea53ae3c68a07082e33b390c12d6f46cdc05295b576c68e69f530785200
 schema: olm.template.basic
 

--- a/config.yaml
+++ b/config.yaml
@@ -109,3 +109,7 @@ channels:
         replaces: openshift-gitops-operator.v1.21.2
         skipRange: '>=1.21.0 <1.21.3'
         bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:fce1d54e71537778298a00840ccbbed2d45dc35ae50679e2730ded3acd852d5e
+      - name: openshift-gitops-operator.v1.21.4
+        replaces: openshift-gitops-operator.v1.21.3
+        skipRange: '>=1.21.0 <1.21.4'
+        bundle: quay.io/redhat-user-workloads/rh-openshift-gitops-tenant/gitops-operator-bundle@sha256:1b321ea53ae3c68a07082e33b390c12d6f46cdc05295b576c68e69f530785200


### PR DESCRIPTION
This PR updates the catalog using the release-candidate bundle build.<br>**Build:** v1.21.4-0 <br>**Timestamp:** 20260820-145628 <br><br>Automatically generated by GitHub Actions.